### PR TITLE
Move Communion rune task to 2nd floor.

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,9 +193,8 @@
         <h3 id="Lecture_Building_1st_Floor"><a href="http://bloodborne.wiki.fextralife.com/Lecture+Building">Lecture Building 1st Floor</a> (Optional) <span id="playthrough_totals_12"></span></h3>
         <ul>
           <li data-id="playthrough_12_1">To reach this location, let the <a href="http://bloodborne.wiki.fextralife.com/Lesser+Amygdala">Lesser Amygdala</a> in the church to the right of the <a href="http://bloodborne.wiki.fextralife.com/Grand+Cathedral">Grand Cathedral</a> kill you while having the <a href="http://bloodborne.wiki.fextralife.com/Tonsil+Stone">Tonsil Stone</a> in your inventory</li>
-          <li data-id="playthrough_12_2">Obtain <a href="http://bloodborne.wiki.fextralife.com/Communion">Communion Rune</a> (Tier 2)</li>
-          <li data-id="playthrough_12_3">Leave the lecture building through the large doors at the end of the hall to the <a href="http://bloodborne.wiki.fextralife.com/Nightmare+Frontier">Nightmare Frontier</a>. Can be quite difficult right now, suggested to return later. Beware of the poison water</li>
-          <li data-id="playthrough_12_4">Obtain the <a href="http://bloodborne.wiki.fextralife.com/Augur+of+Ebrietas">Augur of Ebrietas</a></li>
+          <li data-id="playthrough_12_2">Leave the lecture building through the large doors at the end of the hall to the <a href="http://bloodborne.wiki.fextralife.com/Nightmare+Frontier">Nightmare Frontier</a>. Can be quite difficult right now, suggested to return later. Beware of the poison water</li>
+          <li data-id="playthrough_12_3">Obtain the <a href="http://bloodborne.wiki.fextralife.com/Augur+of+Ebrietas">Augur of Ebrietas</a></li>
         </ul>
 
         <h3 id="Nightmare_Frontier"><a href="http://bloodborne.wiki.fextralife.com/Nightmare+Frontier">Nightmare Frontier</a> (Optional) <span id="playthrough_totals_13"></span></h3>
@@ -265,7 +264,8 @@
         <h3 id="Lecture_Building_2nd_Floor"><a href="http://bloodborne.wiki.fextralife.com/Lecture+Building+2nd+Floor">Lecture Building 2nd Floor</a> <span id="playthrough_totals_21"></span></h3>
         <ul>
           <li data-id="playthrough_21_1">Open shortcut to <a href="http://bloodborne.wiki.fextralife.com/Lecture+Building+2nd+Floor">Lecture Building 1st Floor</a></li>
-          <li data-id="playthrough_21_2">Exit the area to access <a href="http://bloodborne.wiki.fextralife.com/Nightmare+of+Mensis">Nightmare of Mensis</a></li>
+          <li data-id="playthrough_21_2">Obtain <a href="http://bloodborne.wiki.fextralife.com/Communion">Communion Rune</a> (Tier 2)</li>
+          <li data-id="playthrough_21_3">Exit the area to access <a href="http://bloodborne.wiki.fextralife.com/Nightmare+of+Mensis">Nightmare of Mensis</a></li>
         </ul>
 
         <h3 id="Nightmare_of_Mensis"><a href="http://bloodborne.wiki.fextralife.com/Nightmare+of+Mensis">Nightmare of Mensis</a> <span id="playthrough_totals_22"></span></h3>


### PR DESCRIPTION
Communion rune is on the 2nd floor as fextralife points out (https://bloodborne.wiki.fextralife.com/Lecture+Building+2nd+Floor).