### PR TITLE
Scrollbar always on to avoid jumping effect + typo

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,3 +1,4 @@
+html { overflow-y:scroll; }
 table { width: 100%; }
 th { text-align: left;}
 .table-striped tbody tr:nth-child(odd) td, .table-striped tbody tr:nth-child(odd) th { background-color: #E9E9E9;}

--- a/index.html
+++ b/index.html
@@ -762,7 +762,7 @@
           <p>Nope, not really. This is a set of checklists and information that you can use while playing Dark Souls to make sure you don't miss an item, action, conversation or boss. If you need playthroughs then you can click on the links scattered throughout the page to find them in the wiki.</p>
 
           <h3>Do I need to follow the playthrough in this exact order?</h3>
-          <p>Bloodborne is not a liner game and has multiple ways of progressing. This is generally the way I like to play through the game, so feel free to follow it if you like or mix it up. You can always jump back and forth and check things off in a different order.</p>
+          <p>Bloodborne is not a linear game and has multiple ways of progressing. This is generally the way I like to play through the game, so feel free to follow it if you like or mix it up. You can always jump back and forth and check things off in a different order.</p>
 
           <h3>Can I use this for multiple characters?</h3>
           <p>Yup, use the profile selector and buttons at the top right of the page to setup multiple characters.</p>


### PR DESCRIPTION
Since menu items "Information" and "Help" normally doesn't need the scrollbar, the page makes a "jump" when switching between those 2 items and the others. This fixes that