### PR TITLE
Add chalices checklist

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
           <li class="active"><a href="#tabPlaythrough" data-toggle="tab">Playthrough</a></li>
           <li><a href="#tabChecklists" data-toggle="tab">Checklists</a></li>
           <li><a href="#tabSets" data-toggle="tab">Armor by sets</a></li>
+          <li><a href="#tabDungeons" data-toggle="tab">Chalice Dungeons</a></li>
           <li><a href="#tabInformation" data-toggle="tab">Information</a></li>
           <li><a href="#tabHelp" data-toggle="tab">Help</a></li>
         </ul>
@@ -712,6 +713,53 @@
           <li data-id="sets_36_4"><a href="https://bloodborne.wiki.fextralife.com/Wine+Hakama">Wine Hakama</a></li>
         </ul>
         <hr />
+      </div>
+      <div class="tab-pane" id="tabDungeons">
+        <h2>Chalice Dungeons Checklist <span id="chalice_overall_total"></span></h2>
+        <ul>
+          <li><a href="#Pthumeru">Pthumeru Chalices</a> <span id="chalice_nav_totals_1"></span></li>
+          <li><a href="#Hintertomb">Hintertomb Chalices</a> <span id="chalice_nav_totals_2"></span></li>
+          <li><a href="#Loran">Loran Chalices</a> <span id="chalice_nav_totals_3"></span></li>
+          <li><a href="#Isz">Isz Chalices</a> <span id="chalice_nav_totals_4"></span></li>
+        </ul>
+        <div>For more info, checkout the <a href="https://bloodborne.wiki.fextralife.com/Chalice+Dungeon">Chalice Dungeon</a> summary page.</div>
+        <h3 id="Pthumeru">Pthumeru Chalices <span id="chalice_totals_1"></span></h3>
+        <ul>
+          <li data-id="chalice_1_1"><a href="https://bloodborne.wiki.fextralife.com/Pthumeru+Chalice">Pthumeru Chalice</a> (Depth 1) - Kill the <a href="https://bloodborne.wiki.fextralife.com/Blood-starved+Beast">Blood-starved Beast</a> in <a href="https://bloodborne.wiki.fextralife.com/Old+Yharnam">Old Yharnam</a>.</li>
+          <li data-id="chalice_1_2"><a href="https://bloodborne.wiki.fextralife.com/Pthumeru+Root+Chalice">Pthumeru Root Chalice</a> (Depth 1) - Kill the <a href="https://bloodborne.wiki.fextralife.com/Merciless+Watcher">Merciless Watcher</a> in <a href="https://bloodborne.wiki.fextralife.com/Pthumeru+Chalice">Pthumeru Chalice</a> (Layer 2).</li>
+          <li data-id="chalice_1_3"><a href="https://bloodborne.wiki.fextralife.com/Central+Pthumeru+Chalice">Central Pthumeru Chalice</a> (Depth 2) - Kill the <a href="https://bloodborne.wiki.fextralife.com/Watchdog+of+the+Old+Lords">Watchdog of the Old Lords</a> in <a href="https://bloodborne.wiki.fextralife.com/Pthumeru+Chalice">Pthumeru Chalice</a> (Layer 3).</li>
+          <li data-id="chalice_1_4"><a href="https://bloodborne.wiki.fextralife.com/Central+Pthumeru+Root+Chalice">Central Pthumeru Root Chalice</a> (Depth 2) - Kill the <a href="">Keeper of the Old Lords</a> in <a href="https://bloodborne.wiki.fextralife.com/Central+Pthumeru+Chalice">Central Pthumeru Chalice</a> (Layer 2).</li>
+          <li data-id="chalice_1_5"><a href="https://bloodborne.wiki.fextralife.com/Lower+Pthumeru+Chalice">Lower Pthumeru Chalice</a> (Depth 3) - Kill the <a href="https://bloodborne.wiki.fextralife.com/Pthumerian+Descendant">Pthumerian Descendant</a> in <a href="https://bloodborne.wiki.fextralife.com/Central+Pthumeru+Chalice">Central Pthumeru Chalice</a> (Layer 3).</li>
+          <li data-id="chalice_1_6"><a href="https://bloodborne.wiki.fextralife.com/Lower+Pthumeru+Root+Chalice">Lower Pthumeru Root Chalice</a> (Depth 3) - Kill <a href="https://bloodborne.wiki.fextralife.com/Rom%2C+the+Vacuous+Spider">Rom, the Vacuous Spider</a> in <a href="https://bloodborne.wiki.fextralife.com/Lower+Pthumeru+Chalice">Lower Pthumeru Chalice</a> (Layer 3).</li>
+          <li data-id="chalice_1_7"><a href="https://bloodborne.wiki.fextralife.com/Sinister+Lower+Pthumeru+Root+Chalice">Sinister Lower Pthumeru Root Chalice</a> (Depth 3) - Sold by <a href="https://bloodborne.wiki.fextralife.com/Messengers">Messengers</a> for 9,000 <a href="https://bloodborne.wiki.fextralife.com/Blood+Echoes">Blood Echoes</a> inside <a href="https://bloodborne.wiki.fextralife.com/Lower+Pthumeru+Chalice">Lower Pthumeru Chalice</a> (Layer 4 behind an illusory wall in the room with the pyromancer).</li>
+          <li data-id="chalice_1_8"><a href="https://bloodborne.wiki.fextralife.com/Defiled+Chalice">Defiled Chalice</a> (Depth 4) - Kill the <a href="https://bloodborne.wiki.fextralife.com/Bloodletting+Beast">Bloodletting Beast</a> in <a href="https://bloodborne.wiki.fextralife.com/Lower+Pthumeru+Chalice">Lower Pthumeru Chalice</a> (Layer 4).</li>
+          <li data-id="chalice_1_9"><a href="https://bloodborne.wiki.fextralife.com/Cursed+and+Defiled+Root+Chalice">Cursed and Defiled Root Chalice</a> (Depth 4) - Kill the <a href="https://bloodborne.wiki.fextralife.com/Watchdog+of+the+Old+Lords">Watchdog of the Old Lords</a> in <a href="https://bloodborne.wiki.fextralife.com/Defiled+Chalice">Defiled Chalice</a> (Layer 2).</li>
+          <li data-id="chalice_1_10"><a href="https://bloodborne.wiki.fextralife.com/Great+Pthumeru+Ihyll+Chalice">Great Pthumeru Ihyll Chalice</a> (Depth 5) - Kill <a href="https://bloodborne.wiki.fextralife.com/Amygdala">Amygdala</a> in <a href="https://bloodborne.wiki.fextralife.com/Defiled+Chalice">Defiled Chalice</a> (Layer 3).</li>
+          <li data-id="chalice_1_11"><a href="https://bloodborne.wiki.fextralife.com/Pthumeru+Ihyll+Root+Chalice">Pthumeru Ihyll Root Chalice</a> (Depth 5) - Kill the Headless <a href="https://bloodborne.wiki.fextralife.com/Bloodletting+Beast">Bloodletting Beast</a> in <a href="https://bloodborne.wiki.fextralife.com/Great+Pthumeru+Ihyll+Chalice">Great Pthumeru Ihyll Chalice</a> (Layer 2).</li>
+          <li data-id="chalice_1_12"><a href="https://bloodborne.wiki.fextralife.com/Sinister+Pthumeru+Ihyll+Root+Chalice">Sinister Pthumeru Ihyll Root Chalice</a> (Depth 5) - Sold by <a href="https://bloodborne.wiki.fextralife.com/Messengers">Messengers</a> for 16,000 <a href="https://bloodborne.wiki.fextralife.com/Blood+Echoes">Blood Echoes</a> inside <a href="https://bloodborne.wiki.fextralife.com/Great+Pthumeru+Ihyll+Chalice">Great Pthumeru Ihyll Chalice</a> (Layer 3 side area).</li>
+        </ul>
+        <h3 id="Hintertomb">Hintertomb Chalices <span id="chalice_totals_2"></span></h3>
+        <ul>
+          <li data-id="chalice_2_1"><a href="https://bloodborne.wiki.fextralife.com/Hintertomb+Chalice">Hintertomb Chalice</a> (Depth 2) - 	In a chest in <a href="https://bloodborne.wiki.fextralife.com/Central+Pthumeru+Chalice">Central Pthumeru Chalice</a> (Layer 2 side area).</li>
+          <li data-id="chalice_2_2"><a href="https://bloodborne.wiki.fextralife.com/Hintertomb+Root+Chalice">Hintertomb Root Chalice</a> (Depth 2) - Kill the <a href="https://bloodborne.wiki.fextralife.com/Undead+Giant">Undead Giant</a> in <a href="https://bloodborne.wiki.fextralife.com/Hintertomb+Root+Chalice">Hintertomb Root Chalice</a> (Layer 2).</li>
+          <li data-id="chalice_2_3"><a href="https://bloodborne.wiki.fextralife.com/Lower+Hintertomb+Chalice">Lower Hintertomb Chalice</a> (Depth 3) - Kill the <a href="https://bloodborne.wiki.fextralife.com/Blood-starved+Beast">Blood-starved Beast</a> in <a href="https://bloodborne.wiki.fextralife.com/Hintertomb+Root+Chalice">Hintertomb Root Chalice</a> (Layer 3).</li>
+          <li data-id="chalice_2_4"><a href="https://bloodborne.wiki.fextralife.com/Lower+Hintertomb+Root+Chalice">Lower Hintertomb Root Chalice</a> (Depth 3) - Kill the <a href="https://bloodborne.wiki.fextralife.com/Forgotten+Madman">Forgotten Madman</a> in <a href="https://bloodborne.wiki.fextralife.com/Lower+Hintertomb+Chalice">Lower Hintertomb Chalice</a> (Layer 2).</li>
+          <li data-id="chalice_2_5"><a href="https://bloodborne.wiki.fextralife.com/Sinister+Hintertomb+Root+Chalice">Sinister Hintertomb Root Chalice</a> (Depth 3) - Sold by <a href="https://bloodborne.wiki.fextralife.com/Messengers">Messengers</a> for 10,000 <a href="https://bloodborne.wiki.fextralife.com/Blood+Echoes">Blood Echoes</a> inside <a href="https://bloodborne.wiki.fextralife.com/Lower+Hintertomb+Chalice">Lower Hintertomb Chalice</a> (Layer 3).</li>
+        </ul>
+        <h3 id="Loran">Loran Chalices <span id="chalice_totals_3"></span></h3>
+        <ul>
+          <li data-id="chalice_3_1"><a href="https://bloodborne.wiki.fextralife.com/Ailing+Loran+Chalice">Ailing Loran Chalice</a> (Depth 4) - 	Kill <a href="https://bloodborne.wiki.fextralife.com/Amygdala">Amygdala</a> in <a href="https://bloodborne.wiki.fextralife.com/Nightmare+Frontier">Nightmare Frontier</a>.</li>
+          <li data-id="chalice_3_2"><a href="https://bloodborne.wiki.fextralife.com/Ailing+Loran+Root+Chalice">Ailing Loran Root Chalice</a> (Depth 4) - Kill the <a href="https://bloodborne.wiki.fextralife.com/Blood-starved+Beast">Blood-starved Beast</a> in <a href="https://bloodborne.wiki.fextralife.com/Ailing+Loran+Chalice">Ailing Loran Chalice</a>  (Layer 2).</li>
+          <li data-id="chalice_3_3"><a href="https://bloodborne.wiki.fextralife.com/Lower+Loran+Chalice">Lower Loran Chalice</a> (Depth 5) - Kill the <a href="https://bloodborne.wiki.fextralife.com/Abhorrent+Beast">Abhorrent Beast</a> in <a href="https://bloodborne.wiki.fextralife.com/Ailing+Loran+Chalice">Ailing Loran Chalice</a>  (Layer 3).</li>
+          <li data-id="chalice_3_4"><a href="https://bloodborne.wiki.fextralife.com/Lower+Ailing+Loran+Root+Chalice">Lower Ailing Loran Root Chalice</a> (Depth 5) - Kill <a href="https://bloodborne.wiki.fextralife.com/Loran+Darkbeast">Loran Darkbeast</a> in <a href="https://bloodborne.wiki.fextralife.com/Lower+Loran+Chalice">Lower Loran Chalice</a> (Layer 3).</li>
+          <li data-id="chalice_3_5"><a href="https://bloodborne.wiki.fextralife.com/Sinister+Lower+Loran+Root+Chalice">Sinister Lower Ailing Loran Root Chalice</a> (Depth 5) - Sold by <a href="https://bloodborne.wiki.fextralife.com/Messengers">Messengers</a> for 18,000 <a href="https://bloodborne.wiki.fextralife.com/Blood+Echoes">Blood Echoes</a> inside <a href="https://bloodborne.wiki.fextralife.com/Lower+Loran+Chalice">Lower Loran Chalice</a> (Layer 3).</li>
+        </ul>
+        <h3 id="Isz">Isz Chalices <span id="chalice_totals_4"></span></h3>
+        <ul>
+          <li data-id="chalice_4_1"><a href="https://bloodborne.wiki.fextralife.com/Great+Isz+Chalice">Great Isz Chalice</a> (Depth 5) - 	Kill <a href="https://bloodborne.wiki.fextralife.com/Ebrietas%2C+Daughter+of+the+Cosmos">Ebrietas, Daughter of the Cosmos</a> in <a href="https://bloodborne.wiki.fextralife.com/Upper+Cathedral+Ward">Upper Cathedral Ward</a>.</li>
+          <li data-id="chalice_4_2"><a href="https://bloodborne.wiki.fextralife.com/Isz+Root+Chalice">Isz Root Chalice</a> (Depth 5) - Kill <a href="https://bloodborne.wiki.fextralife.com/Ebrietas%2C+Daughter+of+the+Cosmos">Ebrietas, Daughter of the Cosmos</a> in <a href="https://bloodborne.wiki.fextralife.com/Great+Isz+Chalice">Great Isz Chalice</a> (Layer 3).</li>
+          <li data-id="chalice_4_3"><a href="https://bloodborne.wiki.fextralife.com/Sinister+Isz+Root+Chalice">Sinister Isz Loran Chalice</a> (Depth 5) - Sold by <a href="https://bloodborne.wiki.fextralife.com/Messengers">Messengers</a> for 20,000 <a href="https://bloodborne.wiki.fextralife.com/Blood+Echoes">Blood Echoes</a> inside <a href="https://bloodborne.wiki.fextralife.com/Great+Isz+Chalice">Great Isz Chalice</a> (Layer 3).</li>
+        </ul>
       </div>
       <div class="tab-pane" id="tabInformation">
         <h2>Information</h2>


### PR DESCRIPTION
Add a checklist to keep track of chalice dungeons because thre are only six ritual altars but twenty-five different chalice dungeons are available.