### PR TITLE
Fix some typos

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,7 +316,7 @@
         <h3 id="fishing_hamlet"><a href="https://bloodborne.wiki.fextralife.com/Fishing+Hamlet">Fishing Hamlet</a> (The Old Hunters) <span id="playthrough_totals_26"></span></h3>
         <ul>
             <li data-id="playthrough_26_1">Obtain <a href="https://bloodborne.wiki.fextralife.com/Accursed+Brew">Accursed Brew</a> while wearing the Milkweed Rune</li>
-            <li data-id="playthrough_26_6">Obtain <a href="https://bloodborne.wiki.fextralife.com/Rakuyo">Rakuyo</a> by defeating the <a href="https://bloodborne.wiki.fextralife.com/Shark-Giant">Shark-Giant</a> hanging on the ceiling of the well</li>
+            <li data-id="playthrough_26_11">Obtain <a href="https://bloodborne.wiki.fextralife.com/Rakuyo">Rakuyo</a> by defeating the <a href="https://bloodborne.wiki.fextralife.com/Shark-Giant">Shark-Giant</a> hanging on the ceiling of the well</li>
             <li data-id="playthrough_26_2">Obtain <a href="https://bloodborne.wiki.fextralife.com/Underground+Cell+Inner+Chamber+Key">Underground Cell Inner Chamber Key</a></li>
             <li data-id="playthrough_26_3">Obtain <a href="https://bloodborne.wiki.fextralife.com/Brador%27s+Set">Brador's Set</a> from Brador, Brador's Testimony is back under the Research Hall
               <ul>
@@ -741,8 +741,8 @@
         <h3 id="Hintertomb">Hintertomb Chalices <span id="chalice_totals_2"></span></h3>
         <ul>
           <li data-id="chalice_2_1"><a href="https://bloodborne.wiki.fextralife.com/Hintertomb+Chalice">Hintertomb Chalice</a> (Depth 2) - 	In a chest in <a href="https://bloodborne.wiki.fextralife.com/Central+Pthumeru+Chalice">Central Pthumeru Chalice</a> (Layer 2 side area).</li>
-          <li data-id="chalice_2_2"><a href="https://bloodborne.wiki.fextralife.com/Hintertomb+Root+Chalice">Hintertomb Root Chalice</a> (Depth 2) - Kill the <a href="https://bloodborne.wiki.fextralife.com/Undead+Giant">Undead Giant</a> in <a href="https://bloodborne.wiki.fextralife.com/Hintertomb+Root+Chalice">Hintertomb Root Chalice</a> (Layer 2).</li>
-          <li data-id="chalice_2_3"><a href="https://bloodborne.wiki.fextralife.com/Lower+Hintertomb+Chalice">Lower Hintertomb Chalice</a> (Depth 3) - Kill the <a href="https://bloodborne.wiki.fextralife.com/Blood-starved+Beast">Blood-starved Beast</a> in <a href="https://bloodborne.wiki.fextralife.com/Hintertomb+Root+Chalice">Hintertomb Root Chalice</a> (Layer 3).</li>
+          <li data-id="chalice_2_2"><a href="https://bloodborne.wiki.fextralife.com/Hintertomb+Root+Chalice">Hintertomb Root Chalice</a> (Depth 2) - Kill the <a href="https://bloodborne.wiki.fextralife.com/Undead+Giant">Undead Giant</a> in <a href="https://bloodborne.wiki.fextralife.com/Hintertomb+Chalice">Hintertomb Chalice</a> (Layer 2).</li>
+          <li data-id="chalice_2_3"><a href="https://bloodborne.wiki.fextralife.com/Lower+Hintertomb+Chalice">Lower Hintertomb Chalice</a> (Depth 3) - Kill the <a href="https://bloodborne.wiki.fextralife.com/Blood-starved+Beast">Blood-starved Beast</a> in <a href="https://bloodborne.wiki.fextralife.com/Hintertomb+Chalice">Hintertomb Chalice</a> (Layer 3).</li>
           <li data-id="chalice_2_4"><a href="https://bloodborne.wiki.fextralife.com/Lower+Hintertomb+Root+Chalice">Lower Hintertomb Root Chalice</a> (Depth 3) - Kill the <a href="https://bloodborne.wiki.fextralife.com/Forgotten+Madman">Forgotten Madman</a> in <a href="https://bloodborne.wiki.fextralife.com/Lower+Hintertomb+Chalice">Lower Hintertomb Chalice</a> (Layer 2).</li>
           <li data-id="chalice_2_5"><a href="https://bloodborne.wiki.fextralife.com/Sinister+Hintertomb+Root+Chalice">Sinister Hintertomb Root Chalice</a> (Depth 3) - Sold by <a href="https://bloodborne.wiki.fextralife.com/Messengers">Messengers</a> for 10,000 <a href="https://bloodborne.wiki.fextralife.com/Blood+Echoes">Blood Echoes</a> inside <a href="https://bloodborne.wiki.fextralife.com/Lower+Hintertomb+Chalice">Lower Hintertomb Chalice</a> (Layer 3).</li>
         </ul>


### PR DESCRIPTION
First fix is in Fishing Hamlet checkboxes, playthrought_26_6 id was duplicated, there are 11 checkboxes but right now page show 10 as max count.
Second fix is typo about Hintertomb Chalices. Items are not in Root but the simple dungeon.